### PR TITLE
fixed my bad

### DIFF
--- a/Source/OmniCoreDrill/ThingDefGenerator.cs
+++ b/Source/OmniCoreDrill/ThingDefGenerator.cs
@@ -42,7 +42,7 @@ public static class ThingDefGenerator
 
             var recipe = new RecipeDef
             {
-                efficiencyStat = StatDefOf.DeepDrillingSpeed,
+                efficiencyStat = StatDefOf.MiningYield,
                 workSpeedStat = StatDefOf.DeepDrillingSpeed,
                 effectWorking = EffecterDefOf.Drill,
                 workSkillLearnFactor = 0.2f,


### PR DESCRIPTION
guess who's careless enough to overlook mining yield as mining speed? orz

the problem isn't prominent on ordinary situations, say, lvl20 mining normal pawn which I tested on. but it stacks worse when the pawn has drill hands